### PR TITLE
STUD-4492: Read Only Mount Support

### DIFF
--- a/cmd_factory.go
+++ b/cmd_factory.go
@@ -80,9 +80,10 @@ func convertMount[T mountable](m Mount) T {
 	switch v := any(&res).(type) {
 	case *docker.HostMount:
 		*v = docker.HostMount{
-			Type:   m.Type,
-			Source: m.Source,
-			Target: m.Destination,
+			Type:     m.Type,
+			Source:   m.Source,
+			Target:   m.Destination,
+			ReadOnly: isReadOnly(m),
 		}
 	case *specs.Mount:
 		*v = specs.Mount{
@@ -93,4 +94,13 @@ func convertMount[T mountable](m Mount) T {
 		}
 	}
 	return res
+}
+
+func isReadOnly(m Mount) bool {
+	for _, opt := range m.Options {
+		if opt == "ro" {
+			return true
+		}
+	}
+	return false
 }

--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -159,7 +159,12 @@ func (t *createTask) buildCreateContainerArgs(c Containerd) []string {
 	defer t.transaction.StartSegment("buildCreateContainerArgs").End()
 	args := []string{"--namespace", c.Namespace, "create", "--name", t.generateContainerName(), "--user", t.opts.User}
 	for _, m := range t.opts.Mounts {
-		args = append(args, "-v", fmt.Sprintf("%s:%s", m.Source, m.Destination))
+		mountString := fmt.Sprintf("%s:%s", m.Source, m.Destination)
+		if len(m.Options) > 0 {
+			opts := strings.Join(m.Options, ",")
+			mountString = fmt.Sprintf("%s:%s", mountString, opts)
+		}
+		args = append(args, "-v", mountString)
 	}
 	for _, e := range t.opts.Env {
 		args = append(args, "-e", e)

--- a/containerd_execution_test.go
+++ b/containerd_execution_test.go
@@ -119,3 +119,87 @@ func Test_createTask_cleanup_ErrNotIgnored(t *testing.T) {
 	mockTask.AssertExpectations(t)
 	mockContainer.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
 }
+
+func Test_createTask_buildCreateContainerArgs(t *testing.T) {
+	client := new(client)
+	cd := Containerd{
+		ContainerdClient: client,
+		Namespace:        "k8s.io",
+	}
+
+	task := &createTask{
+		opts: CreateTaskOptions{
+			Mounts: []specs.Mount{
+				{
+					Destination: "/go/src",
+					Source:      "/command/1",
+					Type:        "bind",
+				},
+				{
+					Destination: "/opt/libs/1",
+					Source:      "/plugin/1/2",
+					Type:        "bind",
+					Options:     []string{"ro", "ab"},
+				},
+			},
+			Env: []string{
+				"A=B",
+				"C=D",
+			},
+			User: "61000",
+			CommandDetails: CommandDetails{
+				ChainExecutorId: 1,
+				ExecutorId:      2,
+				ResultId:        3,
+			},
+			Image: "docker-agent:latest",
+		},
+		labels: map[string]string{
+			"unit-test": "true",
+		},
+	}
+
+	args := task.buildCreateContainerArgs(cd)
+	for i := 0; i < len(args); i++ {
+		var assertion func(t assert.TestingT, a any, b any, msgAndArgs ...any) bool = assert.Equal
+		var firstArg interface{}
+		var secondArg interface{} = args[i]
+		switch i {
+		case 0:
+			firstArg = "--namespace"
+		case 1:
+			firstArg = cd.Namespace
+		case 2:
+			firstArg = "create"
+		case 3:
+			firstArg = "--name"
+		case 4:
+			firstArg = args[i]
+			secondArg = "chains-1-2-3-"
+			assertion = assert.Contains
+		case 5:
+			firstArg = "--user"
+		case 6:
+			firstArg = "61000"
+		case 7, 9:
+			firstArg = "-v"
+		case 8:
+			firstArg = "/command/1:/go/src"
+		case 10:
+			firstArg = "/plugin/1/2:/opt/libs/1:ro,ab"
+		case 11, 13:
+			firstArg = "-e"
+		case 12:
+			firstArg = "A=B"
+		case 14:
+			firstArg = "C=D"
+		case 15:
+			firstArg = "--label"
+		case 16:
+			firstArg = "unit-test=true"
+		case 17:
+			firstArg = task.opts.Image
+		}
+		assertion(t, firstArg, secondArg)
+	}
+}


### PR DESCRIPTION
## Purpose
Add backend support to use read-only mounts on docker and containerd

This will be used when mounting the shared library mounts 

## Semantic Versioning (check one)

- [x] The following were changed in a non-backward compatible way and requires a major version bump:
  - _[link to the breaking change in the diff]_
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
      release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
