### PR TITLE
STUD-4944 Include Stderr

### DIFF
--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -137,7 +137,7 @@ func (t *createTask) executeCreateContainer(args ...string) (containerId string,
 	cmd.Stdout = stdout
 	cmd.Stderr = stdErr
 	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("%s: %w", stdErr.String(), err)
+		return "", fmt.Errorf("%w: %s", err, stdErr.String())
 	}
 	containerId = strings.TrimSpace(stdout.String())
 	return containerId, nil

--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -137,7 +137,7 @@ func (t *createTask) executeCreateContainer(args ...string) (containerId string,
 	cmd.Stdout = stdout
 	cmd.Stderr = stdErr
 	if err = cmd.Run(); err != nil {
-		return "", err
+		return "", fmt.Errorf("%s: %w", stdErr.String(), err)
 	}
 	containerId = strings.TrimSpace(stdout.String())
 	return containerId, nil


### PR DESCRIPTION
## Purpose

If the `nerdctl` command fails, include stderr in the error


## Semantic Versioning (check one)

- [x] The following were changed in a non-backward compatible way and requires a major version bump:
  - _[link to the breaking change in the diff]_
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
      release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
