### PR TITLE
STUD-4971 Remove Leases

### DIFF
--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -75,12 +75,12 @@ func (t *createTask) create(c Containerd, cmd []string) error {
 
 	t.buildLabels()
 
-	container, err := t.createContainer(c)
+	var err error
+	t.container, err = t.createContainer(c)
 
 	if err != nil {
 		return fmt.Errorf("error creating container: %w", err)
 	}
-	t.container = container
 
 	return nil
 }

--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -137,7 +137,7 @@ func (t *createTask) loadContainer(c Containerd, containerId string) (container 
 			t.logger.Debugf("LoadContainer operation took %d ms", dur)
 		}
 	}(time.Now())
-	ctx := newrelic.NewContext(t.newContext(), t.transaction)
+	ctx := t.newNewrelicContext()
 	container, err = c.LoadContainer(ctx, containerId)
 	return container, err
 }

--- a/containerd_execution.go
+++ b/containerd_execution.go
@@ -55,7 +55,6 @@ type createTask struct {
 	cmd         []string
 	process     containerd.Process
 	exitChan    <-chan containerd.ExitStatus
-	tmpDir      string
 	logger      *logrus.Entry
 	labels      map[string]string
 	deadline    time.Time

--- a/containerd_execution_test.go
+++ b/containerd_execution_test.go
@@ -1,7 +1,6 @@
 package dexec
 
 import (
-	"context"
 	"errors"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
@@ -33,7 +32,6 @@ func Test_createTask_run(t *testing.T) {
 
 	ct := &createTask{
 		container: mockContainer,
-		ctx:       context.Background(),
 	}
 	client := new(client)
 	client.On("IsServing", mock.Anything).Return(true, nil)
@@ -71,7 +69,6 @@ func Test_createTask_createProcessSpec(t *testing.T) {
 			User:       "61000",
 			WorkingDir: "/go/src",
 		},
-		ctx: context.Background(),
 	}
 
 	spec := &oci.Spec{Process: &specs.Process{}}
@@ -89,8 +86,7 @@ func Test_createTask_createProcessSpec(t *testing.T) {
 func Test_createTask_cleanup_NotFoundErrIgnoredOnTaskDelete(t *testing.T) {
 	mockContainer := new(container)
 	mockTask := new(task)
-	ctx := context.Background()
-	ct := &createTask{container: mockContainer, task: mockTask, ctx: ctx}
+	ct := &createTask{container: mockContainer, task: mockTask}
 
 	mockTask.
 		On("Delete", mock.Anything, mock.Anything).
@@ -109,8 +105,7 @@ func Test_createTask_cleanup_NotFoundErrIgnoredOnTaskDelete(t *testing.T) {
 func Test_createTask_cleanup_ErrNotIgnored(t *testing.T) {
 	mockContainer := new(container)
 	mockTask := new(task)
-	ctx := context.Background()
-	ct := &createTask{container: mockContainer, task: mockTask, ctx: ctx}
+	ct := &createTask{container: mockContainer, task: mockTask}
 	expectedErr := errors.New("unit test")
 	mockTask.
 		On("Delete", mock.Anything, mock.Anything).


### PR DESCRIPTION
## Purpose

With the containers being created from nerdctl, we no longer need to use/manage leases for expiration

## Solution

Remove lease usage

## Semantic Versioning (check one)

- [x] The following were changed in a non-backward compatible way and requires a major version bump:
  - _[link to the breaking change in the diff]_
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
      release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
